### PR TITLE
add "packaging_format" key to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
     "name": "Wallabag",
     "id": "wallabag",
+    "packaging_format": 1,
     "description": {
         "en": "A self hostable read-it-later app",
         "fr": "Une application de lecture-plus-tard auto-hébergeable" 


### PR DESCRIPTION
Following the decision taken during last meeting.

See "## Format version (packaging_version)" here http://pv.yunohost.org/meeting/63-yunohost-3-2016/